### PR TITLE
Simplify M2M PK handling in crud_flows

### DIFF
--- a/easyaudit/signals/crud_flows.py
+++ b/easyaudit/signals/crud_flows.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-from collections.abc import Iterable
 from uuid import UUID
 
 from django.conf import settings
@@ -102,12 +101,12 @@ def m2m_changed_crud_flow(  # noqa: PLR0913
         if action == "post_clear":
             changed_fields = []
         else:
-            pks = pk_set
-            if isinstance(pks, Iterable):
-                pks = (format_primary_key(pk) for pk in pks)
-            else:
-                pks = format_primary_key(pks)
-            changed_fields = {get_m2m_field_name(model, instance): list(pks)}
+            pks = (
+                []
+                if pk_set is None
+                else [format_primary_key(pk) for pk in pk_set]
+            )
+            changed_fields = {get_m2m_field_name(model, instance): pks}
         log_event(
             event_type,
             instance,

--- a/easyaudit/signals/crud_flows.py
+++ b/easyaudit/signals/crud_flows.py
@@ -101,11 +101,7 @@ def m2m_changed_crud_flow(  # noqa: PLR0913
         if action == "post_clear":
             changed_fields = []
         else:
-            pks = (
-                []
-                if pk_set is None
-                else [format_primary_key(pk) for pk in pk_set]
-            )
+            pks = [] if pk_set is None else [format_primary_key(pk) for pk in pk_set]
             changed_fields = {get_m2m_field_name(model, instance): pks}
         log_event(
             event_type,


### PR DESCRIPTION
## Summary

Cherry-picks the M2M primary-key handling change from [soynatan/django-easy-audit#340](https://github.com/soynatan/django-easy-audit/pull/340) commit [`bfe2ced`](https://github.com/soynatan/django-easy-audit/pull/340/changes/bfe2ced4a05d2151a8bd7acdb1f2b89d681b638d) onto current `master`.

- Drop the broad `Iterable` check and generator expression when logging M2M `changed_fields`
- Always build a list via `format_primary_key`, with an explicit empty list when `pk_set` is `None`
- Keeps fork-specific `get_instance_metadata()` behavior (not included in upstream PR #340’s metadata removal commit)

## Test plan

- [x] CI passes on this branch
- [ ] M2M add/remove/clear events still record correct `changed_fields` (including UUID PK models)
- [x] After merge, tag a release


Made with [Cursor](https://cursor.com)